### PR TITLE
Ensure the value of spelllang has been parsed for current window

### DIFF
--- a/lua/spellsitter.lua
+++ b/lua/spellsitter.lua
@@ -18,6 +18,8 @@ local function setup_spellcheck()
 
     typedef int ErrorType;
 
+    typedef unsigned char char_u;
+
     typedef struct {
       ErrorType type;
       char *msg;
@@ -30,6 +32,8 @@ local function setup_spellcheck()
     size_t spell_check(
       win_T *wp, const char *ptr, hlf_T *attrp,
       int *capcol, bool docount);
+
+    char_u *did_set_spelllang(win_T *wp);
   ]]
 
   local capcol = ffi.new("int[1]", -1)
@@ -58,6 +62,14 @@ local HLF_SPB = 30
 local function spell_check_iter(text, winid)
   local err = ffi.new("Error[1]")
   local w = ffi.C.find_window_by_handle(winid, err)
+
+  -- Ensure that the spell language is set for the window. By ensuring this is
+  -- set, it prevents an early return from the spelling function that skips
+  -- the spell checking.
+  local err_spell_lang = ffi.C.did_set_spelllang(w)
+  if not err_spell_lang then
+      print("ERROR: Failed to set spell languages.", err_spell_lang)
+  end
 
   local sum = 0
 


### PR DESCRIPTION
It seems that there are occasions like in #8 where the spelling isn't
working correctly. This is because the value of spelllang hasn't yet
been parsed for the window. This results in the check for the loading of
the language files causing an early return from the spell check
function. The problematic line is [375 of neovim's spell.c](https://github.com/neovim/neovim/blob/1c416892879de6b78038f2cc2f1487eff46abb60/src/nvim/spell.c#L375)

By running the `did_set_spellang` function before running the spell
checks, this ensures that these laguage files have been appropriately
loaded.

Fixes #8