### PR TITLE
Fix: ensure buffer is loaded in buf_enabled

### DIFF
--- a/lua/spellsitter.lua
+++ b/lua/spellsitter.lua
@@ -170,6 +170,9 @@ local excluded_filetypes = {
 }
 
 local function buf_enabled(bufnr)
+  if not api.nvim_buf_is_loaded(bufnr) then
+    return false
+  end
   if pcall(api.nvim_buf_get_var, bufnr, 'current_syntax') then
     return false
   end


### PR DESCRIPTION
This PR adds a check at the top of `buf_enabled` to ensure that a buffer is loaded and returns false if not since it seems to me that any other check isn't worth it if the buffer isn't loaded. This fixes #21 . I wasn't sure though if there was a subtlety I was missing so another possible fix is adding a pcall at the specific error line (176)

```lua
  local ok_ft, ft = pcall(api.nvim_buf_get_option(bufnr, 'filetype'))
  if ok_ft and excluded_filetypes[ft] then
    return false
  end
```