### PR TITLE
Add new spell checker based on vim.fn.spellbadword()

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,5 +59,11 @@ the default settings:
 require('spellsitter').setup {
   hl = 'SpellBad',
   captures = {'comment'},  -- set to {} to spellcheck everything
+
+  -- Spellchecker to use. values:
+  -- * vimfn: built-in spell checker using vim.fn.spellbadword()
+  -- * ffi: built-in spell checker using the FFI to access the
+  --   internal spell_check() function
+  spellchecker = 'vimfn',
 }
 ```

--- a/lua/spellsitter/spellcheck/ffi.lua
+++ b/lua/spellsitter/spellcheck/ffi.lua
@@ -1,0 +1,97 @@
+local ffi = require("ffi")
+
+ffi.cdef[[
+  typedef void win_T;
+
+  typedef int ErrorType;
+
+  typedef unsigned char char_u;
+
+  typedef struct {
+    ErrorType type;
+    char *msg;
+  } Error;
+
+  win_T* find_window_by_handle(int window, Error *err);
+
+  typedef int hlf_T;
+
+  size_t spell_check(
+    win_T *wp, const char *ptr, hlf_T *attrp,
+    int *capcol, bool docount);
+
+  char_u *did_set_spelllang(win_T *wp);
+]]
+
+local capcol = ffi.new("int[1]", -1)
+local hlf = ffi.new("hlf_T[1]", 0)
+
+local spell_check = function(win_handle, text)
+  hlf[0] = 0
+  capcol[0] = -1
+
+  local len
+  -- FIXME: Spell check can segfault on strings that begin with punctuation.
+  -- Probably a bug in the C function.
+  local leading_punc = text:match('^%p+')
+  if leading_punc then
+    len = #leading_punc
+  else
+    len = tonumber(ffi.C.spell_check(win_handle, text, hlf, capcol, false))
+  end
+
+  return len, tonumber(hlf[0])
+end
+
+local HLF_SPB
+local HLF_SPR
+local HLF_SPL
+
+if vim.version().minor == 5 then
+  HLF_SPB = 30
+  HLF_SPR = 32
+  HLF_SPL = 33
+else
+  HLF_SPB = 32
+  HLF_SPR = 34
+  HLF_SPL = 35
+end
+
+local err = ffi.new("Error[1]")
+
+local function on_win(_, winid, _)
+  -- Ensure that the spell language is set for the window. By ensuring this is
+  -- set, it prevents an early return from the spelling function that skips
+  -- the spell checking.
+  local w = ffi.C.find_window_by_handle(winid, err)
+  local err_spell_lang = ffi.C.did_set_spelllang(w)
+  if not err_spell_lang then
+      print("ERROR: Failed to set spell languages.", err_spell_lang)
+  end
+end
+
+local ns = vim.api.nvim_create_namespace('spellsitter.spellcheck.ffi')
+vim.api.nvim_set_decoration_provider(ns, {
+  on_win = on_win
+})
+
+local function spell_check_iter(text, winid)
+  local w = ffi.C.find_window_by_handle(winid, err)
+
+  local sum = 0
+
+  return function()
+    while #text > 0 do
+      local len, res = spell_check(w, text)
+
+      text = text:sub(len+1, -1)
+      sum = sum + len
+
+      if res == HLF_SPB or res == HLF_SPR or res == HLF_SPL then
+        return sum - len, len
+      end
+    end
+  end
+end
+
+return spell_check_iter

--- a/lua/spellsitter/spellcheck/vimfn.lua
+++ b/lua/spellsitter/spellcheck/vimfn.lua
@@ -1,0 +1,32 @@
+local function spell_check_iter(text, _)
+  local sum = 0
+
+  return function()
+    while #text > 0 do
+      local word, _ = unpack(vim.fn.spellbadword(text))
+      if word == '' then
+        -- No bad words
+        return
+      end
+
+      -- spellbadword() doesn't tell us the location of the bad word so we need
+      -- to find it ourselves.
+      local mstart, mend = text:find('%f[%w]'..word..'%f[%W]')
+      if not mstart then
+        -- happens when vim disagrees with the above lua pattern on what a word
+        -- boundary is
+        return
+      end
+
+      -- shift out the text up-to the end of the bad word we just found
+      text = text:sub(mend+1)
+      sum = sum + mend
+
+      local len = mend - mstart + 1
+
+      return sum - len, len
+    end
+  end
+end
+
+return spell_check_iter

--- a/test.lua
+++ b/test.lua
@@ -1,0 +1,4 @@
+-- badword
+-- helicopter heli
+-- badwordwithdigits12345 and good words
+-- badword good word badword good word badword


### PR DESCRIPTION
Whilst removing dependency on the FFI (which does not work on windows).
This should also be more performant since most lines will require only 1
call to `vim.fn.spellbadword()`.

The FFI version has been kept as an alternate spellchecker as an optional
fallback in case the new vim.fn imp has bugs.
