### PR TITLE
Use treesitter queries for deciding what to spell check

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ the default settings:
 ```lua
 require('spellsitter').setup {
   hl = 'SpellBad',
-  captures = {'comment'},  -- set to {} to spellcheck everything
 
   -- Spellchecker to use. values:
   -- * vimfn: built-in spell checker using vim.fn.spellbadword()

--- a/queries/c/spell.scm
+++ b/queries/c/spell.scm
@@ -1,0 +1,2 @@
+(comment) @spell
+(string_literal) @spell

--- a/queries/latex/spell.scm
+++ b/queries/latex/spell.scm
@@ -1,0 +1,7 @@
+(
+    (text) @spell
+    (#not-has-parent? @spell
+        inline_formula
+        displayed_equation
+    )
+)

--- a/queries/lua/spell.scm
+++ b/queries/lua/spell.scm
@@ -1,0 +1,1 @@
+(comment) @spell

--- a/queries/python/spell.scm
+++ b/queries/python/spell.scm
@@ -1,0 +1,4 @@
+(comment) @spell
+
+; doc-strings
+(expression_statement (string) @spell)

--- a/test/dummy.tex
+++ b/test/dummy.tex
@@ -1,0 +1,12 @@
+
+\documentclass{article}
+\begin{document}
+
+The bAd well known Pythagorean theorem \(x^2 + y^2 = z^2\) was
+proved to be invalid for other exponents.
+Meaning the next equation has no integer solutions:
+
+\[ x^n + bAd y^n = z^n \]
+
+\end{document}
+


### PR DESCRIPTION
If there is no spell.scm query defined for a filetype then comments are
spell checked.

Resolves #24
