### PR TITLE
Fix "no parser" issue in NvimTree, TelescopePrompt, packer, etc.

### DIFF
--- a/lua/spellsitter.lua
+++ b/lua/spellsitter.lua
@@ -120,7 +120,13 @@ local function on_line(_, winid, bufnr, lnum)
   marks[bufnr] = marks[bufnr] or {}
   marks[bufnr][lnum+1] = nil
 
-  get_parser():for_each_tree(function(tstree, langtree)
+  local success, parser = pcall(get_parser)
+
+  if not success then
+      return
+  end
+
+  parser:for_each_tree(function(tstree, langtree)
     local root_node = tstree:root()
     local spell_query = get_query(langtree:lang())
     if spell_query then

--- a/lua/spellsitter.lua
+++ b/lua/spellsitter.lua
@@ -123,7 +123,7 @@ local function on_line(_, winid, bufnr, lnum)
   local success, parser = pcall(get_parser)
 
   if not success then
-      return
+    return
   end
 
   parser:for_each_tree(function(tstree, langtree)


### PR DESCRIPTION
When in a buffer with spellsitter running and then opening things like NvimTree, Telescope, and packer, I was getting the following error:

`spellsitter: Error executing lua: /usr/share/nvim/runtime/lua/vim/treesitter/language.lua:25: no parser for 'NvimTree' language, see :help treesitter-parsers`

These windows don't pass the conditions in `buf_enabled()`, but it seems like if the previously active buffer was enabled, that it will trigger the error?

The issue doesn't occur when the active buffer does not have spellsitter enabled (e.g. `[No name]` buffer) then switching to one of the above plugins.

The issue also does not seem to occur if the `nvim-treesitter` "highlight" module is not enabled.

I'm not sure if this is the "correct" fix - perhaps there's a way to prevent `on_line()` being call at all when switching to an unsupported buffer.