### PR TITLE
feat(query): support for norg

### DIFF
--- a/queries/norg/spell.scm
+++ b/queries/norg/spell.scm
@@ -1,0 +1,1 @@
+(paragraph_segment) @spell


### PR DESCRIPTION
This seems to capture any text from paragraphs, lists, blockquotes and headings. 

![image](https://user-images.githubusercontent.com/59267627/146233182-b7a5d284-772d-4de0-a59e-894ac2b07120.png)


However, I think text wrapped around accents is meant to be inline code, so I would like ignore it but I cannot find the right predicate to use. Below is the treesitter tree for the last line from the example above.
![image](https://user-images.githubusercontent.com/59267627/146233277-a2446007-0352-451e-a566-02c68d333ed0.png)
