### PR TITLE
Check that vim.treesitter is not nil

### DIFF
--- a/lua/spellsitter.lua
+++ b/lua/spellsitter.lua
@@ -1,5 +1,6 @@
 local query = require'vim.treesitter.query'
 local get_parser = vim.treesitter.get_parser
+local highlighter = vim.treesitter.highlighter
 
 local api = vim.api
 
@@ -149,10 +150,7 @@ local function enabled(bufnr, winid)
   if not vim.wo[winid].spell then
     return false
   end
-  if vim.treesitter ~= nil then
-    return false
-  end
-  if not vim.treesitter.highlighter.active[bufnr] then
+  if not highlighter.active[bufnr] then
     return false
   end
   local ft = vim.bo[bufnr].filetype

--- a/lua/spellsitter.lua
+++ b/lua/spellsitter.lua
@@ -149,6 +149,9 @@ local function enabled(bufnr, winid)
   if not vim.wo[winid].spell then
     return false
   end
+  if vim.treesitter ~= nil then
+    return false
+  end
   if not vim.treesitter.highlighter.active[bufnr] then
     return false
   end


### PR DESCRIPTION
When opening nvim with no file argument. I.e.

    $ nvim

I receive the error

```
(UNKNOWN PLUGIN): Error executing lua: attempt to call a nil value
                                                                  stack traceback:
```

This is a corrupted line of output and i don't know how to get the actual stack trace.

However, i tracked down the bug to commit 504e897, and Line 192 of the enabled function in spellsitter.lua

```
if not vim.treesitter.highlighter.active[bufnr] then
```

It looks like vim.treesitter is nil if there is not a file open (though it could also be that displaying the open file just hides the error above). Here is a patch that fixes it, but i'm not sure if it's the "right" solution. Perhaps oddly, returning false if vim.treesitter is nil results in the same error.
Version info:

```
$ nvim -v
NVIM v0.6.0
Build type: Release
LuaJIT 2.0.5
Compiled by builduser

Features: +acl +iconv +tui
See ":help feature-compile"

   system vimrc file: "$VIM/sysinit.vim"
  fall-back for $VIM: "/usr/share/nvim"
```

Spellsitter: 2cb4700
nvim-treesitter: 288ef60edde1b5a49c325b0770bdf999ae648a92