### PR TITLE
Add spelling support for Ruby comments and strings

### DIFF
--- a/queries/ruby/spell.scm
+++ b/queries/ruby/spell.scm
@@ -1,0 +1,2 @@
+(comment) @spell
+(string_content) @spell


### PR DESCRIPTION
I was looking for a way to turn on spell check for strings without messing around with syntax files. Found this project, and this patch seems to work :)