### PR TITLE
Add Debug option

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ the default settings:
 require('spellsitter').setup {
   -- Whether enabled, can be a list of filetypes, e.g. {'python', 'lua'}
   enable = true,
+  debug = false
 }
 ```
 

--- a/lua/spellsitter.lua
+++ b/lua/spellsitter.lua
@@ -9,6 +9,7 @@ local M = {}
 
 local config = {
   enable = true,
+  debug = false
 }
 
 local ft_to_parsername = {
@@ -101,7 +102,7 @@ local function add_extmark(winid, bufnr, lnum, col, len, highlight)
     ephemeral = true
   })
 
-  if not ok then
+  if config.debug and not ok then
     print(('ERROR: Failed to add extmark, lnum=%d pos=%d'):format(lnum, col))
   end
 


### PR DESCRIPTION
This PR mainly fixes the [#63](https://github.com/lewis6991/spellsitter.nvim/issues/63) issue, which actually happened to me too.

But this error message doesn't help, I think it should be disabled by default, because the default `[s` and `]s` don't bring this kind of information.
